### PR TITLE
feat(moderation): Add previous/next navigation to moderation and user modals

### DIFF
--- a/app/dashboard/moderations/data-table.tsx
+++ b/app/dashboard/moderations/data-table.tsx
@@ -16,6 +16,7 @@ import { DataTableLoading } from "@/components/ui/data-table-loading";
 import { useRouter } from "next/navigation";
 
 import * as schema from "@/db/schema";
+import { useModalCollection } from "@/components/modal-collection-context";
 type ModerationStatus = (typeof schema.moderations.$inferSelect)["status"];
 
 const DataTable = ({ clerkOrganizationId }: { clerkOrganizationId: string }) => {
@@ -28,6 +29,7 @@ const DataTable = ({ clerkOrganizationId }: { clerkOrganizationId: string }) => 
   ]);
   const [globalFilter, setGlobalFilter] = useState("");
   const [sorting, setSorting] = useState<SortingState>([{ id: "sort", desc: true }]);
+  const { setCollection } = useModalCollection();
 
   const query = {
     clerkOrganizationId: clerkOrganizationId,
@@ -81,6 +83,11 @@ const DataTable = ({ clerkOrganizationId }: { clerkOrganizationId: string }) => 
       fetchMoreOnBottomReached(tableContainerRef.current);
     }
   }, [fetchMoreOnBottomReached]);
+
+  useEffect(() => {
+    // Store only record IDs in the collection state since they are used for next/previous navigation
+    setCollection(records.map((record) => record.id));
+  }, [records]);
 
   const router = useRouter();
 

--- a/app/dashboard/records/[recordId]/record.tsx
+++ b/app/dashboard/records/[recordId]/record.tsx
@@ -5,6 +5,7 @@ import { RecordImages } from "./record-images";
 import { Code, CodeInline } from "@/components/code";
 import { Header, HeaderContent, HeaderPrimary, HeaderSecondary, HeaderActions } from "@/components/sheet/header";
 import { Section, SectionContent, SectionTitle } from "@/components/sheet/section";
+import NextPrevButtons from "@/components/prev-next-buttons";
 import { DateFull } from "@/components/date";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
@@ -222,27 +223,7 @@ export async function RecordDetail({ clerkOrganizationId, id }: { clerkOrganizat
           </Section>
         </>
       )}
-
-      {/* Floating Navigation Buttons */}
-      <div className="sticky bottom-0 flex justify-between border-t border-zinc-700 bg-zinc-900 px-4 py-2">
-        <Button
-          asChild
-          variant="outline"
-          // disabled={!previousRecord}
-          className="bg-white px-6 py-2 shadow-lg dark:bg-zinc-800"
-        >
-          {false ? <Link href={`/dashboard/records/${""}`}>← Previous</Link> : <span>← Previous</span>}
-        </Button>
-
-        <Button
-          asChild
-          variant="outline"
-          // disabled={!nextRecord}
-          className="bg-white px-6 py-2 shadow-lg dark:bg-zinc-800"
-        >
-          {false ? <Link href={`/dashboard/records/${""}`}>Next →</Link> : <span>Next →</span>}
-        </Button>
-      </div>
+      <NextPrevButtons recordId={record.id} path="/dashboard/records/" />
     </div>
   );
 }

--- a/app/dashboard/records/[recordId]/record.tsx
+++ b/app/dashboard/records/[recordId]/record.tsx
@@ -222,6 +222,27 @@ export async function RecordDetail({ clerkOrganizationId, id }: { clerkOrganizat
           </Section>
         </>
       )}
+
+      {/* Floating Navigation Buttons */}
+      <div className="sticky bottom-0 flex justify-between border-t border-zinc-700 bg-zinc-900 px-4 py-2">
+        <Button
+          asChild
+          variant="outline"
+          // disabled={!previousRecord}
+          className="bg-white px-6 py-2 shadow-lg dark:bg-zinc-800"
+        >
+          {false ? <Link href={`/dashboard/records/${""}`}>← Previous</Link> : <span>← Previous</span>}
+        </Button>
+
+        <Button
+          asChild
+          variant="outline"
+          // disabled={!nextRecord}
+          className="bg-white px-6 py-2 shadow-lg dark:bg-zinc-800"
+        >
+          {false ? <Link href={`/dashboard/records/${""}`}>Next →</Link> : <span>Next →</span>}
+        </Button>
+      </div>
     </div>
   );
 }

--- a/app/dashboard/records/[recordId]/record.tsx
+++ b/app/dashboard/records/[recordId]/record.tsx
@@ -1,5 +1,5 @@
 import { Separator } from "@/components/ui/separator";
-import { formatModerationStatus, formatRecordStatus, formatUserStatus, formatVia } from "@/lib/badges";
+import { formatRecordStatus, formatUserStatus } from "@/lib/badges";
 import { ExternalLink, FlaskConical, FlaskConicalOff, ShieldCheck, ShieldOff } from "lucide-react";
 import { RecordImages } from "./record-images";
 import { Code, CodeInline } from "@/components/code";
@@ -223,7 +223,7 @@ export async function RecordDetail({ clerkOrganizationId, id }: { clerkOrganizat
           </Section>
         </>
       )}
-      <NextPrevButtons recordId={record.id} path="/dashboard/records/" />
+      <NextPrevButtons rowId={record.id} path="/dashboard/records/" />
     </div>
   );
 }

--- a/app/dashboard/users/[userId]/user.tsx
+++ b/app/dashboard/users/[userId]/user.tsx
@@ -2,7 +2,7 @@ import { Separator } from "@/components/ui/separator";
 import { formatUser, getUserSecondaryParts } from "@/lib/record-user";
 import db from "@/db";
 import * as schema from "@/db/schema";
-import { formatUserActionStatus, formatVia } from "@/lib/badges";
+import { formatUserActionStatus } from "@/lib/badges";
 import { ExternalLink, ShieldCheck, ShieldOff } from "lucide-react";
 import { Header, HeaderActions, HeaderContent, HeaderPrimary, HeaderSecondary } from "@/components/sheet/header";
 import { Section, SectionContent, SectionTitle } from "@/components/sheet/section";
@@ -20,6 +20,7 @@ import { StripeAccount } from "./stripe-account";
 import { notFound } from "next/navigation";
 import { parseMetadata } from "@/services/metadata";
 import { formatLink } from "@/lib/url";
+import NextPrevButtons from "@/components/prev-next-buttons";
 
 export async function UserDetail({ clerkOrganizationId, id }: { clerkOrganizationId: string; id: string }) {
   const user = await db.query.users.findFirst({
@@ -162,6 +163,7 @@ export async function UserDetail({ clerkOrganizationId, id }: { clerkOrganizatio
           <RecordsTable clerkOrganizationId={clerkOrganizationId} userId={user.id} />
         </SectionContent>
       </Section>
+      <NextPrevButtons rowId={user.id} path="/dashboard/users/" />
     </div>
   );
 }

--- a/app/dashboard/users/data-table.tsx
+++ b/app/dashboard/users/data-table.tsx
@@ -16,6 +16,7 @@ import { DataTableLoading } from "@/components/ui/data-table-loading";
 import { useRouter } from "next/navigation";
 
 import * as schema from "@/db/schema";
+import { useModalCollection } from "@/components/modal-collection-context";
 type UserActionStatus = (typeof schema.userActions.status.enumValues)[number];
 
 const DataTable = ({ clerkOrganizationId }: { clerkOrganizationId: string }) => {
@@ -26,6 +27,7 @@ const DataTable = ({ clerkOrganizationId }: { clerkOrganizationId: string }) => 
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([{ id: "status", value: [] }]);
   const [globalFilter, setGlobalFilter] = useState("");
   const [sorting, setSorting] = useState<SortingState>([{ id: "sort", desc: true }]);
+  const { setCollection } = useModalCollection();
 
   const query = {
     clerkOrganizationId,
@@ -78,6 +80,11 @@ const DataTable = ({ clerkOrganizationId }: { clerkOrganizationId: string }) => 
       fetchMoreOnBottomReached(tableContainerRef.current);
     }
   }, [fetchMoreOnBottomReached]);
+
+  useEffect(() => {
+    // Store only record IDs in the collection state since they are used for next/previous navigation
+    setCollection(users.map((user) => user.id));
+  }, [users]);
 
   const router = useRouter();
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,6 +12,7 @@ import { cn } from "@/lib/utils";
 import { ClerkProvider } from "@clerk/nextjs";
 import TRPCProvider from "@/components/trpc";
 import { ConfirmProvider } from "@/components/ui/confirm";
+import { ModalCollectionProvider } from "@/components/modal-collection-context";
 
 const fontSans = FontSans({
   subsets: ["latin"],
@@ -33,21 +34,23 @@ export const metadata: Metadata = {
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <TRPCProvider>
-      <ClerkProvider>
-        <ConfirmProvider>
-          <html lang="en" suppressHydrationWarning>
-            <body
-              className={cn("bg-background min-h-screen font-sans antialiased", fontSans.variable, fontMono.variable)}
-              suppressHydrationWarning
-            >
-              <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
-                {children}
-                <Toaster />
-              </ThemeProvider>
-            </body>
-          </html>
-        </ConfirmProvider>
-      </ClerkProvider>
+      <ModalCollectionProvider>
+        <ClerkProvider>
+          <ConfirmProvider>
+            <html lang="en" suppressHydrationWarning>
+              <body
+                className={cn("bg-background min-h-screen font-sans antialiased", fontSans.variable, fontMono.variable)}
+                suppressHydrationWarning
+              >
+                <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+                  {children}
+                  <Toaster />
+                </ThemeProvider>
+              </body>
+            </html>
+          </ConfirmProvider>
+        </ClerkProvider>
+      </ModalCollectionProvider>
     </TRPCProvider>
   );
 }

--- a/components/modal-collection-context.tsx
+++ b/components/modal-collection-context.tsx
@@ -26,7 +26,7 @@ export function ModalCollectionProvider({ children }: { children: React.ReactNod
   );
 }
 
-export function useModalCollection(recordId?: string) {
+export function useModalCollection(rowId?: string) {
   const context = useContext(ModalCollectionContext);
   if (!context) {
     throw new Error("useModalCollection must be used within a ModalCollectionProvider");
@@ -35,8 +35,8 @@ export function useModalCollection(recordId?: string) {
   const { collection, setCollection, currentIndex, setCurrentIndex } = context;
 
   const index = useMemo(() => {
-    return collection.findIndex((id) => String(id) === recordId);
-  }, [collection, recordId]);
+    return collection.findIndex((id) => String(id) === rowId);
+  }, [collection, rowId]);
 
   useEffect(() => {
     if (index !== -1 && index !== currentIndex) {
@@ -47,7 +47,7 @@ export function useModalCollection(recordId?: string) {
   return {
     setCollection,
     currentIndex: index !== -1 ? index : undefined,
-    previousRecordId: index > 0 ? collection[index - 1] : null,
-    nextRecordId: index < collection.length - 1 ? collection[index + 1] : null,
+    previousRowId: index > 0 ? collection[index - 1] : null,
+    nextRowId: index < collection.length - 1 ? collection[index + 1] : null,
   };
 }

--- a/components/modal-collection-context.tsx
+++ b/components/modal-collection-context.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { createContext, useContext, useState, useMemo, useEffect } from "react";
+import * as schema from "@/db/schema";
+
+type ModerationId = (typeof schema.moderations.$inferSelect)["id"];
+type userId = (typeof schema.users.$inferSelect)["id"];
+
+type ModalCollectionContextType = {
+  collection: ModerationId[] | userId[];
+  setCollection: React.Dispatch<React.SetStateAction<ModerationId[] | userId[]>>;
+  currentIndex: number | undefined;
+  setCurrentIndex: React.Dispatch<React.SetStateAction<number | undefined>>;
+};
+
+const ModalCollectionContext = createContext<ModalCollectionContextType | null>(null);
+
+export function ModalCollectionProvider({ children }: { children: React.ReactNode }) {
+  const [collection, setCollection] = useState<ModerationId[] | userId[]>([]);
+  const [currentIndex, setCurrentIndex] = useState<number | undefined>(undefined);
+
+  return (
+    <ModalCollectionContext.Provider value={{ collection, setCollection, currentIndex, setCurrentIndex }}>
+      {children}
+    </ModalCollectionContext.Provider>
+  );
+}
+
+export function useModalCollection(recordId?: string) {
+  const context = useContext(ModalCollectionContext);
+  if (!context) {
+    throw new Error("useModalCollection must be used within a ModalCollectionProvider");
+  }
+
+  const { collection, setCollection, currentIndex, setCurrentIndex } = context;
+
+  const index = useMemo(() => {
+    return collection.findIndex((id) => String(id) === recordId);
+  }, [collection, recordId]);
+
+  useEffect(() => {
+    if (index !== -1 && index !== currentIndex) {
+      setCurrentIndex(index);
+    }
+  }, [index, currentIndex, setCurrentIndex]);
+
+  return {
+    setCollection,
+    currentIndex: index !== -1 ? index : undefined,
+    previousRecordId: index > 0 ? collection[index - 1] : null,
+    nextRecordId: index < collection.length - 1 ? collection[index + 1] : null,
+  };
+}

--- a/components/prev-next-buttons.tsx
+++ b/components/prev-next-buttons.tsx
@@ -1,0 +1,43 @@
+"use client";
+import React from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { useModalCollection } from "./modal-collection-context";
+
+export const NextPrevButtons = React.forwardRef<HTMLDivElement, { recordId: string; path: string }>(
+  ({ recordId, path }, ref) => {
+    const { previousRecordId, nextRecordId } = useModalCollection(recordId);
+
+    return (
+      <div ref={ref} className="sticky bottom-0 flex justify-between border-t border-zinc-700 bg-zinc-900 px-4 py-2">
+        <Button
+          asChild
+          variant="outline"
+          disabled={Boolean(previousRecordId)}
+          className="bg-white px-6 py-2 shadow-lg dark:bg-zinc-800"
+        >
+          {previousRecordId ? (
+            <Link href={`${path}${previousRecordId}`}>← Previous</Link>
+          ) : (
+            <span className="opacity-50">← Previous</span>
+          )}
+        </Button>
+
+        <Button
+          asChild
+          variant="outline"
+          disabled={Boolean(nextRecordId)}
+          className="bg-white px-6 py-2 shadow-lg dark:bg-zinc-800"
+        >
+          {nextRecordId ? (
+            <Link href={`${path}${nextRecordId}`}>Next →</Link>
+          ) : (
+            <span className="opacity-50">Next →</span>
+          )}
+        </Button>
+      </div>
+    );
+  },
+);
+
+export default NextPrevButtons;

--- a/components/prev-next-buttons.tsx
+++ b/components/prev-next-buttons.tsx
@@ -4,20 +4,20 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { useModalCollection } from "./modal-collection-context";
 
-export const NextPrevButtons = React.forwardRef<HTMLDivElement, { recordId: string; path: string }>(
-  ({ recordId, path }, ref) => {
-    const { previousRecordId, nextRecordId } = useModalCollection(recordId);
+export const NextPrevButtons = React.forwardRef<HTMLDivElement, { rowId: string; path: string }>(
+  ({ rowId, path }, ref) => {
+    const { previousRowId, nextRowId } = useModalCollection(rowId);
 
     return (
       <div ref={ref} className="sticky bottom-0 flex justify-between border-t border-zinc-700 bg-zinc-900 px-4 py-2">
         <Button
           asChild
           variant="outline"
-          disabled={Boolean(previousRecordId)}
+          disabled={Boolean(previousRowId)}
           className="bg-white px-6 py-2 shadow-lg dark:bg-zinc-800"
         >
-          {previousRecordId ? (
-            <Link href={`${path}${previousRecordId}`}>← Previous</Link>
+          {previousRowId ? (
+            <Link href={`${path}${previousRowId}`}>← Previous</Link>
           ) : (
             <span className="opacity-50">← Previous</span>
           )}
@@ -26,14 +26,10 @@ export const NextPrevButtons = React.forwardRef<HTMLDivElement, { recordId: stri
         <Button
           asChild
           variant="outline"
-          disabled={Boolean(nextRecordId)}
+          disabled={Boolean(nextRowId)}
           className="bg-white px-6 py-2 shadow-lg dark:bg-zinc-800"
         >
-          {nextRecordId ? (
-            <Link href={`${path}${nextRecordId}`}>Next →</Link>
-          ) : (
-            <span className="opacity-50">Next →</span>
-          )}
+          {nextRowId ? <Link href={`${path}${nextRowId}`}>Next →</Link> : <span className="opacity-50">Next →</span>}
         </Button>
       </div>
     );

--- a/components/router-sheet.tsx
+++ b/components/router-sheet.tsx
@@ -14,7 +14,7 @@ export function RouterSheet({ children, title }: { children: React.ReactNode; ti
         showClose={false}
         onPointerDownOutside={(e) => {
           e.preventDefault();
-          router.back();
+          router.push("/dashboard/moderations");
         }}
       >
         <VisuallyHidden asChild>

--- a/components/router-sheet.tsx
+++ b/components/router-sheet.tsx
@@ -14,7 +14,7 @@ export function RouterSheet({ children, title }: { children: React.ReactNode; ti
         showClose={false}
         onPointerDownOutside={(e) => {
           e.preventDefault();
-          router.push("/dashboard/moderations");
+          router.push(title === "Record" ? "/dashboard/moderations" : "/dashboard/users");
         }}
       >
         <VisuallyHidden asChild>


### PR DESCRIPTION
**What:**

- Introduces previous/next navigation buttons in the Moderation and User modals.
- Allows seamless navigation within the modal without returning to the table view.

**How:**

- Implements a React context to store an active "collection" of moderation records or users.
- This collection is populated based on the TRPC endpoint results for a given search term or filter setting.
- The context is shared between the TanStack table and the modal, enabling consistent navigation.
- Places the context in the top-level dashboard layout to ensure accessibility for the modals.

**Why:**

- To enhances user experience by allowing quick record browsing within the modal.
- Reduces the need for unnecessary navigation between the table view and the modal.