### PR TITLE
changes to implement previous and next buttons in moderation modal an…

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -3,6 +3,7 @@ import DynamicLayout from "./dynamic-layout";
 import { OrganizationList } from "@clerk/nextjs";
 import { findOrCreateOrganizationSettings } from "@/services/organization-settings";
 import { getInboxCount } from "@/services/appeals";
+import { ActiveCollectionProvider } from "@/components/active-collection-context";
 
 export default async function Layout({ children, sheet }: { children: React.ReactNode; sheet: React.ReactNode }) {
   const { orgId } = await auth();
@@ -19,10 +20,12 @@ export default async function Layout({ children, sheet }: { children: React.Reac
 
   return (
     <>
-      <DynamicLayout organizationSettings={organizationSettings} inboxCount={inboxCount}>
-        {children}
-      </DynamicLayout>
-      {sheet}
+      <ActiveCollectionProvider>
+        <DynamicLayout organizationSettings={organizationSettings} inboxCount={inboxCount}>
+          {children}
+        </DynamicLayout>
+        {sheet}
+      </ActiveCollectionProvider>
     </>
   );
 }

--- a/app/dashboard/moderations/data-table.tsx
+++ b/app/dashboard/moderations/data-table.tsx
@@ -16,6 +16,7 @@ import { DataTableLoading } from "@/components/ui/data-table-loading";
 import { useRouter } from "next/navigation";
 
 import * as schema from "@/db/schema";
+import { useActiveCollection } from "@/components/active-collection-context";
 type ModerationStatus = (typeof schema.moderations.$inferSelect)["status"];
 
 const DataTable = ({ clerkOrganizationId }: { clerkOrganizationId: string }) => {
@@ -28,6 +29,7 @@ const DataTable = ({ clerkOrganizationId }: { clerkOrganizationId: string }) => 
   ]);
   const [globalFilter, setGlobalFilter] = useState("");
   const [sorting, setSorting] = useState<SortingState>([{ id: "sort", desc: true }]);
+  const { setQuery } = useActiveCollection();
 
   const query = {
     clerkOrganizationId: clerkOrganizationId,
@@ -36,9 +38,10 @@ const DataTable = ({ clerkOrganizationId }: { clerkOrganizationId: string }) => 
     entities: (columnFilters.find((filter) => filter.id === "entity")?.value as string[]) || [],
     search: globalFilter || undefined,
   };
-  const { data, fetchNextPage, hasNextPage, isFetching, isLoading } = trpc.record.infinite.useInfiniteQuery(query, {
+  const queryResult = trpc.record.infinite.useInfiniteQuery(query, {
     getNextPageParam: (lastPage) => lastPage.nextCursor,
   });
+  const { data, fetchNextPage, hasNextPage, isFetching, isLoading } = queryResult;
   const records = useMemo(() => data?.pages?.flatMap((page) => page.records) ?? [], [data]);
 
   const table = useReactTable({
@@ -81,6 +84,10 @@ const DataTable = ({ clerkOrganizationId }: { clerkOrganizationId: string }) => 
       fetchMoreOnBottomReached(tableContainerRef.current);
     }
   }, [fetchMoreOnBottomReached]);
+
+  useEffect(() => {
+    setQuery(queryResult);
+  }, [records]);
 
   const router = useRouter();
 

--- a/app/dashboard/records/[recordId]/record-collection-navigation.tsx
+++ b/app/dashboard/records/[recordId]/record-collection-navigation.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { useActiveCollection } from "@/components/active-collection-context";
+import { PreviousNextButtons } from "@/components/previous-next-buttons";
+import { Record } from "../types";
+import { InfiniteData } from "@tanstack/react-query";
+
+interface RecordsCollectionNavigationProps {
+  currentRecordId: string;
+}
+
+type RecordsPage = {
+  records: Record[];
+  nextCursor?: number | undefined;
+};
+
+export function RecordsCollectionNavigation({ currentRecordId }: RecordsCollectionNavigationProps) {
+  const { query } = useActiveCollection<InfiniteData<RecordsPage>>();
+  const isRecordsActiveCollection = query?.data?.pages[0]?.records;
+  const { data, fetchNextPage, hasNextPage } = query ?? {};
+
+  const records: Record[] = React.useMemo(() => data?.pages?.flatMap((page) => page.records) ?? [], [data]);
+
+  const router = useRouter();
+  const onPrevious = (recordId: string) => {
+    router.replace(`/dashboard/records/${recordId}`);
+  };
+
+  const onNext = (recordId: string) => {
+    router.replace(`/dashboard/records/${recordId}`);
+  };
+
+  const fetchNextItems = async () => {
+    if (fetchNextPage) {
+      const { data } = await fetchNextPage();
+      const records: Record[] = data?.pages?.flatMap((page) => page.records) ?? [];
+
+      return records;
+    }
+  };
+
+  if (!isRecordsActiveCollection) return null;
+  return (
+    <div className="sticky bottom-0 px-6 py-2">
+      <PreviousNextButtons
+        currentItemId={currentRecordId}
+        items={records}
+        onPrevious={onPrevious}
+        onNext={onNext}
+        fetchNextItems={fetchNextItems}
+        hasNextItems={hasNextPage}
+      />
+    </div>
+  );
+}

--- a/app/dashboard/records/[recordId]/record.tsx
+++ b/app/dashboard/records/[recordId]/record.tsx
@@ -1,5 +1,5 @@
 import { Separator } from "@/components/ui/separator";
-import { formatModerationStatus, formatRecordStatus, formatUserStatus, formatVia } from "@/lib/badges";
+import { formatRecordStatus, formatUserStatus } from "@/lib/badges";
 import { ExternalLink, FlaskConical, FlaskConicalOff, ShieldCheck, ShieldOff } from "lucide-react";
 import { RecordImages } from "./record-images";
 import { Code, CodeInline } from "@/components/code";
@@ -20,6 +20,7 @@ import * as schema from "@/db/schema";
 import { eq, desc, and } from "drizzle-orm";
 import db from "@/db";
 import { parseMetadata } from "@/services/metadata";
+import { RecordsCollectionNavigation } from "./record-collection-navigation";
 
 export async function RecordDetail({ clerkOrganizationId, id }: { clerkOrganizationId: string; id: string }) {
   const record = await db.query.records.findFirst({
@@ -222,6 +223,7 @@ export async function RecordDetail({ clerkOrganizationId, id }: { clerkOrganizat
           </Section>
         </>
       )}
+      <RecordsCollectionNavigation currentRecordId={id} />
     </div>
   );
 }

--- a/app/dashboard/users/[userId]/records-table.tsx
+++ b/app/dashboard/users/[userId]/records-table.tsx
@@ -11,11 +11,13 @@ import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from "@/comp
 import { FlaskConical } from "lucide-react";
 import { Date } from "@/components/date";
 import { ActionMenu } from "../../records/action-menu";
+import { useActiveCollection } from "@/components/active-collection-context";
 
 export function RecordsTable({ clerkOrganizationId, userId }: { clerkOrganizationId: string; userId: string }) {
   const tableContainerRef = useRef<HTMLDivElement>(null);
+  const { setQuery } = useActiveCollection();
 
-  const { data, fetchNextPage, hasNextPage, isFetching, isLoading } = trpc.record.infinite.useInfiniteQuery(
+  const queryResult = trpc.record.infinite.useInfiniteQuery(
     {
       clerkOrganizationId,
       userId,
@@ -24,6 +26,7 @@ export function RecordsTable({ clerkOrganizationId, userId }: { clerkOrganizatio
       getNextPageParam: (lastPage) => lastPage.nextCursor,
     },
   );
+  const { data, fetchNextPage, hasNextPage, isFetching, isLoading } = queryResult;
   const records = useMemo(() => data?.pages?.flatMap((page) => page.records) ?? [], [data]);
 
   const fetchMoreOnBottomReached = useCallback(
@@ -73,6 +76,7 @@ export function RecordsTable({ clerkOrganizationId, userId }: { clerkOrganizatio
                         <Button
                           asChild
                           variant="link"
+                          onClick={() => setQuery(queryResult)}
                           className="text-md -mx-4 -my-2 block w-full truncate font-normal"
                         >
                           <Link href={`/dashboard/records/${record.id}`}>{record.name}</Link>

--- a/app/dashboard/users/[userId]/user-collection-navigation.tsx
+++ b/app/dashboard/users/[userId]/user-collection-navigation.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { useActiveCollection } from "@/components/active-collection-context";
+import { PreviousNextButtons } from "@/components/previous-next-buttons";
+import { User } from "../types";
+import { InfiniteData } from "@tanstack/react-query";
+
+interface UsersCollectionNavigationProps {
+  currentUserId: string;
+}
+
+type UserPage = {
+  users: User[];
+  nextCursor?: number | undefined;
+};
+
+export function UsersCollectionNavigation({ currentUserId }: UsersCollectionNavigationProps) {
+  const { query } = useActiveCollection<InfiniteData<UserPage>>();
+  const isUsersActiveCollection = query?.data?.pages[0]?.users;
+  const { data, fetchNextPage, hasNextPage } = query ?? {};
+  const users: User[] = React.useMemo(() => data?.pages?.flatMap((page) => page.users) ?? [], [query?.data]);
+
+  const router = useRouter();
+  const onPrevious = (userId: string) => {
+    router.replace(`/dashboard/users/${userId}`);
+  };
+
+  const onNext = (userId: string) => {
+    router.replace(`/dashboard/users/${userId}`);
+  };
+
+  const fetchNextItems = async () => {
+    if (fetchNextPage) {
+      const { data } = await fetchNextPage();
+      const users: User[] = data?.pages?.flatMap((page) => page.users) ?? [];
+
+      return users;
+    }
+  };
+
+  if (!isUsersActiveCollection) return null;
+  return (
+    <div className="sticky bottom-0 px-6 py-2">
+      <PreviousNextButtons
+        currentItemId={currentUserId}
+        items={users}
+        onPrevious={onPrevious}
+        onNext={onNext}
+        fetchNextItems={fetchNextItems}
+        hasNextItems={hasNextPage}
+      />
+    </div>
+  );
+}

--- a/app/dashboard/users/[userId]/user.tsx
+++ b/app/dashboard/users/[userId]/user.tsx
@@ -2,7 +2,7 @@ import { Separator } from "@/components/ui/separator";
 import { formatUser, getUserSecondaryParts } from "@/lib/record-user";
 import db from "@/db";
 import * as schema from "@/db/schema";
-import { formatUserActionStatus, formatVia } from "@/lib/badges";
+import { formatUserActionStatus } from "@/lib/badges";
 import { ExternalLink, ShieldCheck, ShieldOff } from "lucide-react";
 import { Header, HeaderActions, HeaderContent, HeaderPrimary, HeaderSecondary } from "@/components/sheet/header";
 import { Section, SectionContent, SectionTitle } from "@/components/sheet/section";
@@ -20,6 +20,7 @@ import { StripeAccount } from "./stripe-account";
 import { notFound } from "next/navigation";
 import { parseMetadata } from "@/services/metadata";
 import { formatLink } from "@/lib/url";
+import { UsersCollectionNavigation } from "./user-collection-navigation";
 
 export async function UserDetail({ clerkOrganizationId, id }: { clerkOrganizationId: string; id: string }) {
   const user = await db.query.users.findFirst({
@@ -162,6 +163,7 @@ export async function UserDetail({ clerkOrganizationId, id }: { clerkOrganizatio
           <RecordsTable clerkOrganizationId={clerkOrganizationId} userId={user.id} />
         </SectionContent>
       </Section>
+      <UsersCollectionNavigation currentUserId={id} />
     </div>
   );
 }

--- a/components/active-collection-context.tsx
+++ b/components/active-collection-context.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import React from "react";
+import { UseInfiniteQueryResult } from "@tanstack/react-query";
+
+export type ActiveCollectionQueryResult<TData> = UseInfiniteQueryResult<TData, unknown>;
+
+interface ActiveCollectionContextType<TData> {
+  query?: ActiveCollectionQueryResult<TData>;
+  setQuery: React.Dispatch<React.SetStateAction<ActiveCollectionQueryResult<TData> | undefined>>;
+}
+
+const ActiveCollectionContext = React.createContext<ActiveCollectionContextType<any> | undefined>(undefined);
+
+export function ActiveCollectionProvider<TData>({ children }: { children: React.ReactNode }) {
+  const [query, setQuery] = React.useState<ActiveCollectionQueryResult<TData> | undefined>(undefined);
+  const value: ActiveCollectionContextType<TData> = { query, setQuery };
+  return <ActiveCollectionContext.Provider value={value}>{children}</ActiveCollectionContext.Provider>;
+}
+
+export function useActiveCollection<TData>() {
+  const context = React.useContext<ActiveCollectionContextType<TData> | undefined>(ActiveCollectionContext);
+  if (!context) {
+    throw new Error("useActiveCollection must be used within an ActiveCollectionProvider");
+  }
+  return context;
+}

--- a/components/previous-next-buttons.tsx
+++ b/components/previous-next-buttons.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+
+export interface NavigableItem {
+  id: string;
+  [key: string]: any;
+}
+
+export interface PreviousNextButtonsProps {
+  currentItemId: string;
+  items: NavigableItem[];
+  onPrevious: (previousItemId: string) => void;
+  onNext: (nextItemId: string) => void;
+  fetchNextItems?: () => Promise<any>;
+  hasNextItems?: boolean;
+}
+
+export function PreviousNextButtons({
+  currentItemId,
+  items,
+  onPrevious,
+  onNext,
+  fetchNextItems,
+  hasNextItems = false,
+}: PreviousNextButtonsProps) {
+  const [isFetchingNext, setIsFetchingNext] = React.useState(false);
+
+  const currentIndex = items.findIndex((item) => item.id === currentItemId);
+  const exhausted = currentIndex >= 0 && (currentIndex < items.length - 1 || (hasNextItems && fetchNextItems));
+  const canGoPrev = currentIndex > 0;
+  const canGoNext = items[currentIndex + 1];
+
+  const handlePreiousOnClick = () => {
+    const prevItem = items[currentIndex - 1];
+    onPrevious(prevItem!.id);
+  };
+
+  const handleNextOnClick = async () => {
+    if (canGoNext) {
+      const nextItem = items[currentIndex + 1];
+      onNext(nextItem!.id);
+    } else if (hasNextItems && fetchNextItems) {
+      setIsFetchingNext(true);
+      const nextItems: NavigableItem[] = await fetchNextItems();
+      setIsFetchingNext(false);
+      const nextItem = nextItems[currentIndex + 1];
+      // should become available after fetching new page
+      if (nextItem) {
+        onNext(nextItem.id);
+      }
+    }
+  };
+
+  return (
+    <div className="flex justify-between">
+      <Button onClick={handlePreiousOnClick} variant="outline" size="sm" disabled={!canGoPrev}>
+        <ArrowLeft />
+        Previous
+      </Button>
+      <Button onClick={handleNextOnClick} variant="outline" size="sm" disabled={!exhausted || isFetchingNext}>
+        Next
+        <ArrowRight />
+      </Button>
+    </div>
+  );
+}

--- a/components/router-sheet.tsx
+++ b/components/router-sheet.tsx
@@ -16,6 +16,7 @@ export function RouterSheet({ children, title }: { children: React.ReactNode; ti
           e.preventDefault();
           router.back();
         }}
+        disableAnimation={true}
       >
         <VisuallyHidden asChild>
           <SheetTitle>{title}</SheetTitle>

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -53,13 +53,18 @@ interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
     VariantProps<typeof sheetVariants> {
   showClose?: boolean;
+  disableAnimation: boolean;
 }
 
 const SheetContent = React.forwardRef<React.ElementRef<typeof SheetPrimitive.Content>, SheetContentProps>(
-  ({ side = "right", className, children, showClose = true, ...props }, ref) => (
+  ({ side = "right", className, children, showClose = true, disableAnimation, ...props }, ref) => (
     <SheetPortal>
-      <SheetOverlay />
-      <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
+      <SheetOverlay className={disableAnimation ? "!animate-none" : ""} />
+      <SheetPrimitive.Content
+        ref={ref}
+        className={cn(sheetVariants({ side }), disableAnimation ? "!animate-none" : "", className)}
+        {...props}
+      >
         {children}
         {showClose && (
           <SheetPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-white transition-opacity hover:opacity-100 disabled:pointer-events-none data-[state=open]:bg-stone-100 dark:ring-offset-stone-950 dark:focus:ring-stone-300 dark:data-[state=open]:bg-stone-800">


### PR DESCRIPTION
What:

Introduces previous/next navigation buttons in the Moderation and User modals.
Allows seamless navigation within the modal without returning to the table view.
How:

Implements a React context to store an active "collection" of moderation records or users.
This collection is populated based on the TRPC endpoint results for a given search term or filter setting.
The context is shared between the TanStack table and the modal, enabling consistent navigation.
Places the context in the top-level dashboard layout to ensure accessibility for the modals.
Why:

To enhances user experience by allowing quick record browsing within the modal.
Reduces the need for unnecessary navigation between the table view and the modal.

**User modal nested navigation**
https://github.com/user-attachments/assets/85fd80ec-8b47-4802-92c1-f6af25618c2d

**Moderation modal navigation**

https://github.com/user-attachments/assets/fef0e54e-e17c-4ae8-a233-99f2665d899f

Thanks for the feedback on my last PR to this issue. I understand the concern about the scope of changes. However, I haven't changed the architecture—instead, I achieved the requirement with a few adjustments to my previous PR while keeping the implementation simple and maintaining stability.

Let me know if you'd like any refinements, but I believe this approach effectively meets the goal without introducing unnecessary complexity.


**Moderations modal**

https://github.com/user-attachments/assets/c2e6f1c2-fa25-4617-bdf0-35693bba9fe5

**Users modal**

https://github.com/user-attachments/assets/e0002d71-9fd1-4f36-b7de-3b937509833e

this PR addresses issue #38 